### PR TITLE
Support connections to vendor-specific interface classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,12 @@
  */
 
 module.exports = {
-  "extends": ["eslint:recommended", "google"],
+  "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/eslint-recommended",
+      "plugin:@typescript-eslint/recommended",
+      "google"
+  ],
   "env": {
       "browser": true,
       "es6": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serial-polyfill",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "An implementation of the [Serial API](https://wicg.github.io/serial) on top of the [WebUSB API](https://wicg.github.io/webusb) for use with USB-to-serial adapters. Use of this library is limited to hardware and platforms where the device is accessible via the WebUSB API because it has not been claimed by a built-in device driver. This project will be used to prototype the design of the Serial API.",
   "main": "./dist/serial.js",
   "types": "./dist/serial.d.ts",
@@ -12,20 +12,14 @@
     "type": "git",
     "url": "https://github.com/google/web-serial-polyfill.git"
   },
-  "eslintconfig": {
-    "extends": [
-      "eslint:recommended",
-      "google"
-    ]
-  },
   "author": "James C Hollyer",
   "license": "Apache",
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.3",
-    "@typescript-eslint/eslint-plugin": "^1.13.0",
-    "@typescript-eslint/parser": "^1.13.0",
-    "eslint": "^5.10.0",
-    "eslint-config-google": "^0.11.0",
-    "typescript": "^3.5.3"
+    "@typescript-eslint/eslint-plugin": "^2.6.0",
+    "@typescript-eslint/parser": "^2.6.0",
+    "eslint": "^6.6.0",
+    "eslint-config-google": "^0.14.0",
+    "typescript": "^3.6.4"
   }
 }

--- a/serial.ts
+++ b/serial.ts
@@ -346,7 +346,7 @@ export class SerialPort {
     this.readable_ = null;
     this.writable_ = null;
     if (this.device_.opened) {
-      await this.setSignals({dtr: false});
+      await this.setSignals({dtr: false, rts: false});
       await this.device_.close();
     }
   }


### PR DESCRIPTION
This change refactors the polyfill so that it can be configured to filter or and connect to vendor-specific interface classes rather than the standard USB CDC-ACM class.