### PR TITLE
babble fix

### DIFF
--- a/serial.ts
+++ b/serial.ts
@@ -244,7 +244,7 @@ export class SerialPort {
                 this.readable_ = null;
               }),
           new ByteLengthQueuingStrategy({
-            highWaterMark: this.serialOptions_.bufferSize ?? kDefaultBufferSize,
+              highWaterMark: this.serialOptions_.bufferSize ?? this.inEndpoint_.packetSize > kDefaultBufferSize ? this.inEndpoint_.packetSize : kDefaultBufferSize,
           }));
     }
     return this.readable_;
@@ -263,7 +263,7 @@ export class SerialPort {
                 this.writable_ = null;
               }),
           new ByteLengthQueuingStrategy({
-            highWaterMark: this.serialOptions_.bufferSize ?? kDefaultBufferSize,
+            highWaterMark: this.serialOptions_.bufferSize ?? this.outEndpoint_.packetSize > kDefaultBufferSize ? this.outEndpoint_.packetSize : kDefaultBufferSize,
           }));
     }
     return this.writable_;

--- a/serial.ts
+++ b/serial.ts
@@ -122,12 +122,8 @@ class UsbEndpointUnderlyingSource implements UnderlyingSource<Uint8Array> {
     (async (): Promise<void> => {
       let chunkSize;
       if (controller.desiredSize) {
-        if (controller.desiredSize < this.endpoint_.packetSize) {
-          chunkSize = this.endpoint_.packetSize;
-        } else {
-          const d = controller.desiredSize / this.endpoint_.packetSize;
-          chunkSize = Math.ceil(d) * this.endpoint_.packetSize;
-        }
+        const d = controller.desiredSize / this.endpoint_.packetSize;
+        chunkSize = Math.ceil(d) * this.endpoint_.packetSize;
       } else {
         chunkSize = this.endpoint_.packetSize;
       }

--- a/serial.ts
+++ b/serial.ts
@@ -119,8 +119,8 @@ class UsbEndpointUnderlyingSource implements UnderlyingSource<Uint8Array> {
    * @param {ReadableStreamDefaultController} controller
    */
   pull(controller: ReadableStreamDefaultController<Uint8Array>): void {
-    (async (): Promise<void> => {
-      const chunkSize = controller.desiredSize ?? this.endpoint_.packetSize;
+    (async (): Promise<void> => {        
+      const chunkSize = !controller.desiredSize || controller.desiredSize < this.endpoint_.packetSize ? this.endpoint_.packetSize : Math.ceil(this.endpoint_.packetSize / controller.desiredSize) * this.endpoint_.packetSize;
       try {
         const result = await this.device_.transferIn(
             this.endpoint_.endpointNumber, chunkSize);
@@ -244,7 +244,7 @@ export class SerialPort {
                 this.readable_ = null;
               }),
           new ByteLengthQueuingStrategy({
-              highWaterMark: this.serialOptions_.bufferSize ?? this.inEndpoint_.packetSize > kDefaultBufferSize ? this.inEndpoint_.packetSize : kDefaultBufferSize,
+              highWaterMark: this.serialOptions_.bufferSize ?? kDefaultBufferSize,
           }));
     }
     return this.readable_;
@@ -263,7 +263,7 @@ export class SerialPort {
                 this.writable_ = null;
               }),
           new ByteLengthQueuingStrategy({
-            highWaterMark: this.serialOptions_.bufferSize ?? this.outEndpoint_.packetSize > kDefaultBufferSize ? this.outEndpoint_.packetSize : kDefaultBufferSize,
+              highWaterMark: this.serialOptions_.bufferSize ?? kDefaultBufferSize,
           }));
     }
     return this.writable_;


### PR DESCRIPTION
Buffersize for reader and writer should be the maximum of the respective interface's packetsize and the kDefaultBufferSize if no bufferSize is specified in serialOptions.

Reason:
I was getting babble errors when receiving larger amounts of data from a Raspberry Pi Zero. After changing the bufferSize manually to the packetSize reported by the in/out interfaces (both 512) the error went away.

Regards 
 A.J.

(https://stackoverflow.com/questions/49994122/how-to-recover-from-webusb-response-status-babble)


