### PR TITLE
Bump version to 1.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-serial-polyfill",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "An implementation of the [Serial API](https://wicg.github.io/serial) on top of the [WebUSB API](https://wicg.github.io/webusb) for use with USB-to-serial adapters. Use of this library is limited to hardware and platforms where the device is accessible via the WebUSB API because it has not been claimed by a built-in device driver. This project will be used to prototype the design of the Serial API.",
   "main": "./dist/serial.js",
   "types": "./dist/serial.d.ts",
@@ -16,8 +16,8 @@
   "author": "James C Hollyer",
   "license": "Apache",
   "devDependencies": {
-    "@types/w3c-web-serial": "^1.0.1",
-    "@types/w3c-web-usb": "^1.0.3",
+    "@types/w3c-web-serial": "^1.0.3",
+    "@types/w3c-web-usb": "^1.0.6",
     "@types/web": "^0.0.71",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",


### PR DESCRIPTION
Ian Foster (1):
* implemented forget() method (#46)

Reilly Grant (3):
* Update node.js.yml with supported Node.js versions (#44)
* Create an UnderlyingByteSource (#43)
* Fix explicit SerialPort constructor demo